### PR TITLE
Add tolerations and affinity to pod-killer cronjob spec

### DIFF
--- a/charts/pod-killer/Chart.yaml
+++ b/charts/pod-killer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pod-killer/templates/cronjob.yaml
+++ b/charts/pod-killer/templates/cronjob.yaml
@@ -18,6 +18,14 @@ spec:
         spec:
           serviceAccount: {{ include "pod-killer.serviceAccountName" . }}
           restartPolicy: Never
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 11 }}
+          {{- end}}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 11 }}
+          {{- end}}
           containers:
           - name: pod-killer
             image: bitnami/kubectl


### PR DESCRIPTION
tolerations and affinity in values.yaml are now properly linked into the cronjob template