### PR TITLE
feat(charts/permitio-pdp): init

### DIFF
--- a/charts/permitio-pdp/Chart.yaml
+++ b/charts/permitio-pdp/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: permitio-pdp
+description: A Helm chart for the permit.io PDP
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.9.9

--- a/charts/permitio-pdp/templates/_helpers.tpl
+++ b/charts/permitio-pdp/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "permitio-pdp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "permitio-pdp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "permitio-pdp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "permitio-pdp.labels" -}}
+helm.sh/chart: {{ include "permitio-pdp.chart" . }}
+{{ include "permitio-pdp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "permitio-pdp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "permitio-pdp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "permitio-pdp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "permitio-pdp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "permitio-pdp.envFrom" -}}
+envFrom:
+-
+  secretRef:
+    name: {{ .Release.Name }}-secrets
+{{- end}}

--- a/charts/permitio-pdp/templates/deployment.yaml
+++ b/charts/permitio-pdp/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "permitio-pdp.fullname" . }}
+  labels:
+    {{- include "permitio-pdp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "permitio-pdp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "permitio-pdp.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "permitio-pdp.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- range .Values.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: diagnostic
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthy
+              port: diagnostic
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- include "permitio-pdp.envFrom" . | nindent 10 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Ensure it is spread evenly across all AZs
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              {{- include "permitio-pdp.selectorLabels" . | nindent 12 }}
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway

--- a/charts/permitio-pdp/templates/secrets.yml
+++ b/charts/permitio-pdp/templates/secrets.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    {{- include "permitio-pdp.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val }}
+  {{- end }}

--- a/charts/permitio-pdp/templates/secrets.yml
+++ b/charts/permitio-pdp/templates/secrets.yml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 data:
   {{- range $key, $val := .Values.secrets }}
-  {{ $key }}: {{ $val }}
+  {{ $key }}: {{ $val | b64enc }}
   {{- end }}

--- a/charts/permitio-pdp/templates/service.yaml
+++ b/charts/permitio-pdp/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "permitio-pdp.fullname" . }}
+  labels:
+    {{- include "permitio-pdp.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "permitio-pdp.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range .Values.service.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol }}
+    {{- end }}

--- a/charts/permitio-pdp/values.yaml
+++ b/charts/permitio-pdp/values.yaml
@@ -1,0 +1,51 @@
+podAnnotations: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  name: ""
+
+replicaCount: 3
+
+image:
+  repository: permitio/pdp-v2
+  tag: "0.9.9"
+  pullPolicy: IfNotPresent
+
+ports:
+  - name: http
+    port: 7766
+    protocol: TCP
+  - name: diagnostic
+    port: 7000
+    protocol: TCP
+
+service:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 7766
+      protocol: TCP
+    - name: diagnostic
+      port: 7000
+      protocol: TCP
+
+resources:
+  requests:
+    cpu: 256m
+    memory: 512Mi
+  limits:
+    memory: 1Gi
+
+secrets:
+  PDP_API_KEY: ""
+
+imagePullSecrets: []
+securityContext: {}
+podSecurityContext: {}
+
+nodeSelector: {}
+affinity: {}
+tolerations: []


### PR DESCRIPTION
## Summary
- Adds a new Helm chart for deploying the [Permit.io PDP (Policy Decision Point)](https://docs.permit.io/how-to/deploy/deploy-to-production) to Kubernetes
- Includes deployment, service, and secrets templates with configurable values
- Sets up health/readiness probes and topology spread constraints for high availability

## Changes
- `Chart.yaml` - Chart metadata (version 0.1.0, appVersion 0.9.9)
- `values.yaml` - Default configuration values
- `templates/deployment.yaml` - Deployment with probes and topology spread
- `templates/service.yaml` - ClusterIP service exposing HTTP and diagnostic ports
- `templates/secrets.yml` - Secret for PDP_API_KEY
- `templates/_helpers.tpl` - Standard Helm template helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)