### PR TITLE
chore(permito-pdp): strictly require image tag from upstream

### DIFF
--- a/charts/permitio-pdp/Chart.yaml
+++ b/charts/permitio-pdp/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.9.9

--- a/charts/permitio-pdp/templates/deployment.yaml
+++ b/charts/permitio-pdp/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             {{- range .Values.ports }}

--- a/charts/permitio-pdp/values.yaml
+++ b/charts/permitio-pdp/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 3
 
 image:
   repository: permitio/pdp-v2
-  tag: "0.9.9"
+  tag: ""  # Set via helm_release resource in tf-modules
   pullPolicy: IfNotPresent
 
 ports:


### PR DESCRIPTION
Enforce the image tag being provided from the upstream `helm_release` resource in `tf-modules`